### PR TITLE
Handle case where there are no subtitles.

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -224,7 +224,7 @@ const SearchBar: React.FunctionComponent = (props) => {
         try {
             json = JSON.parse(html.match(/(?<=window\.__INITIAL_STATE__ = ){.*}/gm)?.[0]!)
         } catch {
-            return null
+            return { subtitles: null, subtitleNames: null }
         }
         let playback = json.content.media.byId[id].playback
         if (!playback) {
@@ -248,7 +248,7 @@ const SearchBar: React.FunctionComponent = (props) => {
                 subtitles.push((value as any).url)
             }
         }
-        if (!subtitles?.[0]) return error ? ipcRenderer.invoke("download-error", "search") : null
+        if (!subtitles?.[0]) return error ? ipcRenderer.invoke("download-error", "search") : { subtitles: null, subtitleNames: null }
         if (!noDL) ipcRenderer.invoke("download-subtitles", {url: subtitles[0], dest: info.dest, id: info.id, episode: info.episode, kind: info.kind, template, language})
         return {subtitles, subtitleNames}
     }


### PR DESCRIPTION
I found another instance where #62 still happens. I've modified the `parseSubtitlesBeta` function to always return an object in the form of `{ subtitles, subtitleNames }` to ensure the destructure always works, even if there were no subtitles. The rest of the code seems to check for subtitles not existing, but the destructure was throwing an error before it could get there.

This fixes #62.